### PR TITLE
issue-40: タグの有効/無効切り替え機能を追加

### DIFF
--- a/app/components/articles/PostDraftModal.tsx
+++ b/app/components/articles/PostDraftModal.tsx
@@ -79,7 +79,7 @@ export function PostDraftModal({ open, onOpenChange, article, prompts }: PostDra
       }
       onOpenChange(newOpen);
     },
-    [isGenerating, onOpenChange]
+    [isGenerating, onOpenChange],
   );
 
   const handleGenerate = useCallback(async () => {

--- a/app/components/ui/sheet.tsx
+++ b/app/components/ui/sheet.tsx
@@ -1,17 +1,17 @@
-import * as React from "react"
-import * as SheetPrimitive from "@radix-ui/react-dialog"
-import { cva, type VariantProps } from "class-variance-authority"
-import { X } from "lucide-react"
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+import * as React from "react";
 
-import { cn } from "~/lib/utils"
+import { cn } from "~/lib/utils";
 
-const Sheet = SheetPrimitive.Root
+const Sheet = SheetPrimitive.Root;
 
-const SheetTrigger = SheetPrimitive.Trigger
+const SheetTrigger = SheetPrimitive.Trigger;
 
-const SheetClose = SheetPrimitive.Close
+const SheetClose = SheetPrimitive.Close;
 
-const SheetPortal = SheetPrimitive.Portal
+const SheetPortal = SheetPrimitive.Portal;
 
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
@@ -20,13 +20,13 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     className={cn(
       "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
+      className,
     )}
     {...props}
     ref={ref}
   />
-))
-SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
   "fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
@@ -44,8 +44,8 @@ const sheetVariants = cva(
     defaultVariants: {
       side: "right",
     },
-  }
-)
+  },
+);
 
 interface SheetContentProps
   extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
@@ -57,11 +57,7 @@ const SheetContent = React.forwardRef<
 >(({ side = "right", className, children, ...props }, ref) => (
   <SheetPortal>
     <SheetOverlay />
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side }), className)}
-      {...props}
-    >
+    <SheetPrimitive.Content ref={ref} className={cn(sheetVariants({ side }), className)} {...props}>
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
@@ -69,36 +65,21 @@ const SheetContent = React.forwardRef<
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>
-))
-SheetContent.displayName = SheetPrimitive.Content.displayName
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
 
-const SheetHeader = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
+const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col space-y-2 text-center sm:text-left", className)} {...props} />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
-    className={cn(
-      "flex flex-col space-y-2 text-center sm:text-left",
-      className
-    )}
+    className={cn("flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2", className)}
     {...props}
   />
-)
-SheetHeader.displayName = "SheetHeader"
-
-const SheetFooter = ({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
-      className
-    )}
-    {...props}
-  />
-)
-SheetFooter.displayName = "SheetFooter"
+);
+SheetFooter.displayName = "SheetFooter";
 
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
@@ -109,8 +90,8 @@ const SheetTitle = React.forwardRef<
     className={cn("text-lg font-semibold text-foreground", className)}
     {...props}
   />
-))
-SheetTitle.displayName = SheetPrimitive.Title.displayName
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
@@ -121,8 +102,8 @@ const SheetDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
-SheetDescription.displayName = SheetPrimitive.Description.displayName
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
 
 export {
   Sheet,
@@ -135,4 +116,4 @@ export {
   SheetFooter,
   SheetTitle,
   SheetDescription,
-}
+};

--- a/app/components/ui/switch.tsx
+++ b/app/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+import * as React from "react";
+
+import { cn } from "~/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className,
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-5 w-5 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-5 data-[state=unchecked]:translate-x-0",
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/app/lib/rss/tag-matcher.ts
+++ b/app/lib/rss/tag-matcher.ts
@@ -21,6 +21,10 @@ export function matchTags(
   const matched: MatchedTag[] = [];
 
   for (const tag of tags) {
+    if (!tag.is_active) {
+      continue;
+    }
+
     const hasMatch = tag.keywords.some((kw) => text.includes(kw.keyword.toLowerCase()));
 
     if (hasMatch) {

--- a/app/lib/tags/tags.server.ts
+++ b/app/lib/tags/tags.server.ts
@@ -9,6 +9,7 @@ export type TagKeyword = {
 export type Tag = {
   id: string;
   name: string;
+  is_active: boolean;
   created_at: string;
   keywords: TagKeyword[];
 };
@@ -22,7 +23,8 @@ export async function getTags(): Promise<Tag[]> {
   const { data, error } = await supabase
     .from("tags")
     .select("*, keywords:tag_keywords(*)")
-    .order("created_at", { ascending: false });
+    .order("created_at", { ascending: false })
+    .order("id", { ascending: true });
 
   if (error) {
     throw new Error("Failed to fetch tags");
@@ -73,6 +75,31 @@ export async function deleteTag(id: string): Promise<void> {
   if (error) {
     throw new Error("Failed to delete tag");
   }
+}
+
+export type UpdateTagActiveResult = {
+  id: string;
+  name: string;
+  is_active: boolean;
+  created_at: string;
+};
+
+export async function updateTagActive(
+  tagId: string,
+  isActive: boolean,
+): Promise<UpdateTagActiveResult> {
+  const { data, error } = await supabase
+    .from("tags")
+    .update({ is_active: isActive })
+    .eq("id", tagId)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error("Failed to update tag active status");
+  }
+
+  return data;
 }
 
 export async function updateTagKeywords(tagId: string, keywords: string[]): Promise<TagKeyword[]> {

--- a/app/routes/api/cron/cleanup-old-articles.ts
+++ b/app/routes/api/cron/cleanup-old-articles.ts
@@ -1,7 +1,4 @@
-import {
-  createUnauthorizedResponse,
-  verifyCronAuth,
-} from "~/lib/cron/auth.server";
+import { createUnauthorizedResponse, verifyCronAuth } from "~/lib/cron/auth.server";
 import { deleteOldArticles } from "~/lib/rss/articles.server";
 import { getSettings } from "~/lib/settings/settings.server";
 

--- a/app/routes/api/cron/fetch-rss.ts
+++ b/app/routes/api/cron/fetch-rss.ts
@@ -1,7 +1,4 @@
-import {
-  createUnauthorizedResponse,
-  verifyCronAuth,
-} from "~/lib/cron/auth.server";
+import { createUnauthorizedResponse, verifyCronAuth } from "~/lib/cron/auth.server";
 import { fetchAllRssSources } from "~/lib/rss/fetch-rss.server";
 
 export async function loader({ request }: { request: Request }) {

--- a/app/routes/excluded.tsx
+++ b/app/routes/excluded.tsx
@@ -125,7 +125,10 @@ export default function Excluded() {
 
         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center">
           {/* Search */}
-          <form onSubmit={handleSearch} className="flex min-w-0 flex-1 items-center gap-2 sm:flex-none">
+          <form
+            onSubmit={handleSearch}
+            className="flex min-w-0 flex-1 items-center gap-2 sm:flex-none"
+          >
             <div className="relative min-w-0 flex-1 sm:flex-none">
               <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input

--- a/app/routes/favorites.tsx
+++ b/app/routes/favorites.tsx
@@ -131,7 +131,10 @@ export default function Favorites() {
 
         <div className="flex min-w-0 flex-col gap-3 sm:flex-row sm:items-center">
           {/* Search */}
-          <form onSubmit={handleSearch} className="flex min-w-0 flex-1 items-center gap-2 sm:flex-none">
+          <form
+            onSubmit={handleSearch}
+            className="flex min-w-0 flex-1 items-center gap-2 sm:flex-none"
+          >
             <div className="relative min-w-0 flex-1 sm:flex-none">
               <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input

--- a/app/routes/home.tsx
+++ b/app/routes/home.tsx
@@ -160,7 +160,10 @@ export default function Home() {
           <TagFilter tags={tags} />
 
           {/* Search */}
-          <form onSubmit={handleSearch} className="flex min-w-0 flex-1 items-center gap-2 sm:flex-none">
+          <form
+            onSubmit={handleSearch}
+            className="flex min-w-0 flex-1 items-center gap-2 sm:flex-none"
+          >
             <div className="relative min-w-0 flex-1 sm:flex-none">
               <Search className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
               <Input

--- a/app/routes/sources.tsx
+++ b/app/routes/sources.tsx
@@ -252,9 +252,7 @@ export default function SourcesPage() {
                   </Badge>
                   <div className="min-w-0 flex-1">
                     <h3 className="font-medium">{source.name}</h3>
-                    <p className="break-all text-sm text-muted-foreground">
-                      {source.url}
-                    </p>
+                    <p className="break-all text-sm text-muted-foreground">{source.url}</p>
                   </div>
                 </div>
                 <div className="flex items-center gap-1">

--- a/app/types/database.types.ts
+++ b/app/types/database.types.ts
@@ -185,16 +185,19 @@ export type Database = {
         Row: {
           created_at: string;
           id: string;
+          is_active: boolean;
           name: string;
         };
         Insert: {
           created_at?: string;
           id?: string;
+          is_active?: boolean;
           name: string;
         };
         Update: {
           created_at?: string;
           id?: string;
+          is_active?: boolean;
           name?: string;
         };
         Relationships: [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-switch": "^1.2.6",
         "@react-router/node": "7.12.0",
         "@react-router/serve": "7.12.0",
         "@supabase/supabase-js": "^2.93.3",
@@ -2692,6 +2693,76 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
       "integrity": "sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.2.6.tgz",
+      "integrity": "sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-switch/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-switch": "^1.2.6",
     "@react-router/node": "7.12.0",
     "@react-router/serve": "7.12.0",
     "@supabase/supabase-js": "^2.93.3",

--- a/supabase/migrations/20260211014720_add_is_active_to_tags.sql
+++ b/supabase/migrations/20260211014720_add_is_active_to_tags.sql
@@ -1,0 +1,5 @@
+-- Add is_active column to tags table
+ALTER TABLE tags ADD COLUMN is_active BOOLEAN NOT NULL DEFAULT true;
+
+-- Create index for filtering by is_active
+CREATE INDEX idx_tags_is_active ON tags(is_active);

--- a/tests/lib/cron/auth.server.test.ts
+++ b/tests/lib/cron/auth.server.test.ts
@@ -1,8 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createUnauthorizedResponse,
-  verifyCronAuth,
-} from "~/lib/cron/auth.server";
+import { createUnauthorizedResponse, verifyCronAuth } from "~/lib/cron/auth.server";
 
 describe("verifyCronAuth", () => {
   const originalEnv = process.env;

--- a/tests/lib/rss/fetch-rss.test.ts
+++ b/tests/lib/rss/fetch-rss.test.ts
@@ -52,12 +52,14 @@ const mockTags: Tag[] = [
   {
     id: "tag-1",
     name: "AI",
+    is_active: true,
     created_at: "2026-01-01T00:00:00Z",
     keywords: [{ id: "kw-1", tag_id: "tag-1", keyword: "machine learning" }],
   },
   {
     id: "tag-2",
     name: "Cloud",
+    is_active: true,
     created_at: "2026-01-01T00:00:00Z",
     keywords: [{ id: "kw-2", tag_id: "tag-2", keyword: "AWS" }],
   },
@@ -208,7 +210,7 @@ describe("fetchRssSource", () => {
 
     // The URL should be properly encoded before being passed to parseURL
     expect(mockParseURL).toHaveBeenCalledWith(
-      "https://news.google.com/rss/search?q=(Nikon%20OR%20%E3%83%8B%E3%82%B3%E3%83%B3)%20when:1d&hl=ja"
+      "https://news.google.com/rss/search?q=(Nikon%20OR%20%E3%83%8B%E3%82%B3%E3%83%B3)%20when:1d&hl=ja",
     );
     expect(result.errors).toEqual([]);
   });


### PR DESCRIPTION
## Summary
- tagsテーブルに`is_active`カラムを追加
- 無効化されたタグはRSS記事のタグマッチングから除外
- タグ管理UIにトグルスイッチを追加（楽観的更新対応）

## Changes
- マイグレーション: `is_active` BOOLEAN NOT NULL DEFAULT true
- `updateTagActive`関数を追加
- `tag-matcher`で`is_active=false`のタグをスキップ
- `useFetcher`による楽観的更新で並び順を維持
- `getTags`のソートを安定化（created_at + id）

## Test plan
- [ ] タグ一覧でトグルをON/OFFできる
- [ ] トグル切り替え時に並び順が変わらない
- [ ] 無効化したタグはRSS取得時にマッチングされない
- [ ] 全テスト通過

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)